### PR TITLE
Install via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,39 @@ Unit tests for the code in salientregions.
 # Installation
 ## Prerequisites
 * Python 2.7 or 3.5
-* pip
-* The python packages in `requirements.txt`.
-* OpenCV 3.1. There is two ways to install OpenCV:
-  * If you're using Conda, you can install OpenCV with the following command:
+* pip (8.1.2)
 
-  `conda install -c https://conda.anaconda.org/menpo opencv3`
+## Installing the package (via pip)
 
-  * Otherwise, follow the instructions to [install OpenCV 3.1.0 manually](http://opencv-python-tutroals.readthedocs.org/en/latest/py_tutorials/py_setup/py_table_of_contents_setup/py_table_of_contents_setup.html#py-table-of-content-setup)
+`pip install -e git://github.com/c-martinez/SalientDetector-python.git@pip#egg=salientregions`
 
+Afterwards you can import it in Python:
 
-## Installing the package
-To install the package `salientregions`  in your environment:
+```python
+import salientregions as sr
+```
+
+## Installing the package manually
+Clone or download repo. Install requirements from requirements.txt file:
+
+`pip install -r requirements.txt`
+
+Install the package itself:
 
 `pip install .`
 
 To perform tests:
 
 `nosetests test`
+
+## Manually install OpenCV
+OpenCV should be installed via pip, but if you have an older version of pip, you might need to  install it manually. There is two ways to install OpenCV:
+  * If you're using Conda, you can install OpenCV with the following command:
+
+  `conda install -c https://conda.anaconda.org/menpo opencv3`
+
+  * Otherwise, follow the instructions to [install OpenCV 3.1.0 manually](http://opencv-python-tutroals.readthedocs.org/en/latest/py_tutorials/py_setup/py_table_of_contents_setup/py_table_of_contents_setup.html#py-table-of-content-setup)
+
 
 # Getting started
 The source code documentation can be found [here](http://salientdetector-python.readthedocs.io/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 matplotlib
 # ipython
 # ipython-notebook
+opencv-python

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,19 @@
 Setting up the Salient region detection in images package.
 '''
 from setuptools import setup, find_packages
+from pip.req import parse_requirements
 
 with open('README.md') as f:
     readme = f.read()
 
+# Parse requirements.txt file
+lines = parse_requirements('requirements.txt', session=False)
+requirements = [str(item.req) for item in lines]
+
 setup(
     name='salientregions',
     version='0.0.1',
+    install_requires=requirements,
     description='Package for finding salient regions in images',
     long_description=readme,
     author='Netherlands eScience Center',


### PR DESCRIPTION
OpenCV can now be [installed via pip](https://pypi.python.org/pypi/opencv-python/3.1.0.0)! And thus this package can also be made pip installable. The only catch is that it requires pip to be 8.1 or later ([see](https://github.com/pypa/manylinux)).
